### PR TITLE
Fixed slow balancing w fast belts and curved output belts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .idea
+
+.vscode/launch.json
+
+.vscode/settings.json
+
+objects/balancer copy.lua

--- a/additional_types/main.lua
+++ b/additional_types/main.lua
@@ -18,12 +18,16 @@ Balancer.output_lanes = nil
 Balancer.unit_number = nil
 
 --- The buffer, where items are buffered.
----@type SimpleItemStack[]
+---@type {[string]:uint} 
 Balancer.buffer = nil
 
 --- The tick to run this balancer on
 ---@type uint
 Balancer.nth_tick = nil
+
+--- The next input lane to be checked.
+---@type uint
+Balancer.next_input = nil
 
 --- The next output lane to be checked.
 ---@type uint

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.2.2
+Date: 07.25.2024
+  Bugfix:
+    - Fixed issue with balancer output speed capping at 120 items per second. Now caps at 480 items per belt (240 per belt lane)
+    - Fixed issue with curved belts from belt lines running beside balancer counting as valid output belts if the curved belt turned away from the balancer
+  Changes:
+    - Slightly improved performace, but still performance heavy if belt speeds are greater than 60 items per second.
+    - Added mod settings option for toggling curved output belt behavior (ignore cureved output belts by default)
+---------------------------------------------------------------------------------------------------
 Version: 3.2.0
 Date: 10.07.2023
   Bugfix:

--- a/helper/conversion.lua
+++ b/helper/conversion.lua
@@ -1,20 +1,17 @@
----convert_LuaItemStack_to_SimpleItemStack
----@param lua_item_stack LuaItemStack
----@return SimpleItemStack
-function convert_LuaItemStack_to_SimpleItemStack(lua_item_stack)
-    local simple_item = {
-        name = lua_item_stack.name,
-        count = lua_item_stack.count,
-        health = lua_item_stack.health,
-        durability = lua_item_stack.durability,
-    }
-
-    local itemtype = lua_item_stack.prototype.type
-    if itemtype == "ammo" then
-        simple_item.ammo = lua_item_stack.ammo
-    elseif itemtype == "item-with-tags" then
-        simple_item.tags = lua_item_stack.tags
+---convert_items_from_input_to_buffer
+---@param balancer_index uint
+---@param next_input uint
+function convert_items_from_input_to_buffer(balancer_index, next_input)
+    local balancer = global.balancer[balancer_index]
+    local ilane = balancer.input_lanes[next_input]
+    local lane_size = #ilane
+    if lane_size > 0 then
+        for i = 1,lane_size do
+            balancer.buffer[#balancer.buffer + 1] = {
+                name = ilane[i].name,
+                count = ilane[i].count}
+        end
+        -- Will always dump entire lane contents (up to all 4 items on belt lane) into buffer, so clear lane contents
+        ilane.clear()
     end
-
-    return simple_item
 end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "belt-balancer-performance",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "title": "Belt Balancer (Improved Performance)",
   "author": "knoxfighter, archiehalliwell",
   "contact": "archie@halliwell.com.au",

--- a/locale/en/main.cfg
+++ b/locale/en/main.cfg
@@ -3,3 +3,11 @@ balancer-part=Balancer Part
 
 [technology-name]
 belt-balancer=Belt Balancer
+
+[mod-setting-name]
+belt-balancer-performace-ignoreCurvedOutputBelts=Ignore curved belts as balancer outbut belts
+
+
+[mod-setting-description]
+belt-balancer-performace-ignoreCurvedOutputBelts=If true, curved output belts beside balancers won't behave as additional output belts
+

--- a/objects/belt.lua
+++ b/objects/belt.lua
@@ -186,6 +186,7 @@ end
 ---This is the functionality to call, when a new belt-entity is created
 ---@param belt LuaEntity The belt, that is being created
 function belt_functions.built_belt(belt)
+    local ignore_curved_belts_as_output = settings.global["belt-balancer-performace-ignoreCurvedOutputBelts"].value
     -- get nearby balancer
     local into_part, from_part = belt_functions.get_input_output_parts(belt)
 
@@ -194,6 +195,15 @@ function belt_functions.built_belt(belt)
             into_part = nil
         elseif belt.belt_to_ground_type == "output" then
             from_part = nil
+        end
+    end
+
+    -- Fix curved belts on lines beside balancer counting as output lines
+    if ignore_curved_belts_as_output == true then
+        if belt.type == "transport-belt" then
+            if belt.belt_shape ~= "straight" then
+                from_part = nil
+            end
         end
     end
 
@@ -330,6 +340,10 @@ function belt_functions.remove_belt(entity, direction, unit_number, surface, pos
 
         local balancer = global.balancer[into_part.balancer]
         for _, lane in pairs(belt.lanes) do
+            -- make sure it doesn't pick this one next
+            if balancer.next_input == lane then 
+                balancer.next_input = next(balancer.input_lanes, balancer.next_input)
+            end
             -- remove lanes from balancer
             balancer.input_lanes[lane] = nil
             -- remove lanes from part
@@ -397,6 +411,10 @@ function belt_functions.remove_splitter(entity, direction, unit_number, surface,
 
         local balancer = global.balancer[part.part.balancer]
         for _, lane in pairs(belt.lanes) do
+            -- make sure it doesn't pick this one next
+            if balancer.next_input == lane then 
+                balancer.next_input = next(balancer.input_lanes, balancer.next_input)
+            end
             -- remove lanes from balancer
             balancer.input_lanes[lane] = nil
             -- remove lanes from part

--- a/objects/part.lua
+++ b/objects/part.lua
@@ -214,6 +214,10 @@ function part_functions.remove(entity, buffer)
                     -- remove lanes from balancer
                     for _, lane_index in pairs(pos.lanes) do
                         local lane = belt.lanes[lane_index]
+                        -- make sure it doesn't pick this one next
+                        if balancer.next_input == lane then 
+                            balancer.next_input = next(balancer.input_lanes, balancer.next_input)
+                        end
                         balancer.input_lanes[lane] = nil
                     end
                 end
@@ -238,6 +242,10 @@ function part_functions.remove(entity, buffer)
 
             -- remove lanes from balancer
             for _, lane in pairs(belt.lanes) do
+                -- make sure it doesn't pick this one next
+                if balancer.next_input == lane then 
+                    balancer.next_input = next(balancer.input_lanes, balancer.next_input)
+                end
                 balancer.input_lanes[lane] = nil
             end
         end

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,10 @@
+data:extend(
+{
+  {
+    type = "bool-setting",
+    name = "belt-balancer-performace-ignoreCurvedOutputBelts",
+    setting_type = "runtime-global",
+    order = "z1",
+    default_value = true,
+  }
+})


### PR DESCRIPTION
Fixed issue with balancer output capping around 120 items per second per belt.

Added settings for ignoring curved output belts and fixed bug related to them